### PR TITLE
Fix error when `require` files outside of project path

### DIFF
--- a/rplugin/python3/acid/commands/require.py
+++ b/rplugin/python3/acid/commands/require.py
@@ -23,6 +23,7 @@ class Command(BaseCommand):
             ns = path_to_ns(self.nvim)
             if ns is None:
                 warning(
+                    self.nvim,
                     "Unable to require: couldn't find namespace from path."
                 )
                 return None

--- a/rplugin/python3/acid/nvim/__init__.py
+++ b/rplugin/python3/acid/nvim/__init__.py
@@ -99,10 +99,10 @@ def path_to_ns(nvim):
 
     if raw_path_list is None:
         log_warning("Have not found any viable path")
+        return None
     else:
         log_debug("Found path list: {}", raw_path_list)
-
-    return ".".join(raw_path_list)
+        return ".".join(raw_path_list)
 
 
 def get_port_no(nvim):


### PR DESCRIPTION
Executing commands like `goto` often opens a file that is outside of your project.
This file would not have a mapping `ns`.
When opening it would throw errors related to command `require`.

`File ".local/share/nvim/plugged/acid.nvim/rplugin/python3/acid/nvim/__init__.py", line 105
, in path_to_ns
    return ".".join(raw_path_list)
TypeError: can only join an iterable`

and

`TypeError: warning() missing 1 required positional argument: 'message'`