### PR TITLE
Bootstrap

### DIFF
--- a/plugin/acid.vim
+++ b/plugin/acid.vim
@@ -50,4 +50,5 @@ function! s:require()
 endfunction
 
 autocmd VimEnter * AcidInit
+autocmd FileType clojure AcidBootstrap
 autocmd BufWritePost,BufReadPost *.clj call s:require()

--- a/rplugin/python3/acid/commands/__init__.py
+++ b/rplugin/python3/acid/commands/__init__.py
@@ -107,9 +107,9 @@ class BaseCommand(object):
     def do_init(cls, nvim):
         inst = cls(nvim)
         inst.on_init()
-        aucmd = 'autocmd FileType clojure {}'
-        [nvim.command(aucmd.format(v)) for v in cls.build_interfaces(nvim)]
+        cmd_list = cls.build_interfaces(nvim)
         cls.__instances__[cls.name] = inst
+        return cmd_list
 
     @classmethod
     def call(cls, acid, context, *args):


### PR DESCRIPTION
Attempts to fix #6

Doesn't actually fix immediately, but allows acid to be bootstrapped
into the file by running `:AcidBoostrap`.