### PR TITLE
Fix require not happening on file load

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ First, install the python dependencies:
 pip3 install --user neovim
 ```
 
+Update your `~/.lein/profiles.clj` adding the following lines:
+```clj
+[refactor-nrepl "2.3.0-SNAPSHOT"]
+[cider/cider-nrepl "0.14.0"]
+```
+
 Then, add and install acid:
 
 ```vim
@@ -30,10 +36,11 @@ Plug 'clojure-vim/acid.nvim'
 :UpdateRemotePlugins
 ```
 
-Update your `~/.lein/profiles.clj` adding the following lines:
-```clj
-[refactor-nrepl "2.3.0-SNAPSHOT"]
-[cider/cider-nrepl "0.14.0"]
+Acid is a remote plugin. This means it communicates with neovim using the rpc interface.
+For its commands to be available on neovim, one must first update neovims rpc bindings:
+
+```vim
+:UpdateRemotePlugins
 ```
 
 ## Running

--- a/plugin/acid.vim
+++ b/plugin/acid.vim
@@ -51,4 +51,6 @@ endfunction
 
 autocmd VimEnter * AcidInit
 autocmd FileType clojure AcidBootstrap
-autocmd BufWritePost,BufReadPost *.clj call s:require()
+
+autocmd User AcidBootstrapComplete call s:require()
+autocmd BufWritePost *.clj call s:require()

--- a/rplugin/python3/acid/__init__.py
+++ b/rplugin/python3/acid/__init__.py
@@ -156,7 +156,6 @@ class Acid(object):
         if bang or not self.commands:
             self.commands = self.init_commands()
 
-
         [self.nvim.command(cmd) for cmd in self.commands]
 
     @neovim.function("AcidSendNrepl")

--- a/rplugin/python3/acid/__init__.py
+++ b/rplugin/python3/acid/__init__.py
@@ -157,6 +157,7 @@ class Acid(object):
             self.commands = self.init_commands()
 
         [self.nvim.command(cmd) for cmd in self.commands]
+        self.nvim.command("doautocmd User AcidBootstrapComplete")
 
     @neovim.function("AcidSendNrepl")
     def acid_eval(self, data):

--- a/rplugin/python3/acid/commands/__init__.py
+++ b/rplugin/python3/acid/commands/__init__.py
@@ -108,6 +108,7 @@ class BaseCommand(object):
         inst = cls(nvim)
         inst.on_init()
         cmd_list = cls.build_interfaces(nvim)
+        log.log_info("Defining commands {}", "\n".join(cmd_list))
         cls.__instances__[cls.name] = inst
         return cmd_list
 


### PR DESCRIPTION
Since `FileType` would trigger an async call to acid, `:AcidRequire` would never be available on `BufReadPost`.