### PR TITLE
Revise path_to_ns function

### DIFF
--- a/rplugin/python3/acid/nvim/__init__.py
+++ b/rplugin/python3/acid/nvim/__init__.py
@@ -120,7 +120,7 @@ def src_paths(nvim):
     return {'src', *nvim.vars.get('acid_alt_paths', [])}
 
 def get_stop_paths(nvim):
-    return {'test', 'src'}
+    return {'test', 'src', *test_paths(nvim), *src_paths(nvim)}
 
 def find_file_in_path(nvim, msg):
     fname = msg['file']


### PR DESCRIPTION
In the current version, it doesn't search alternate paths when users send codes using `AcidEval`.
So, I revised `path_to_ns` function.

Sometimes `:source-paths` is defined in `project.clj`.
``` clojure
  :source-paths ["src" "src/alts"]
```
Alternate paths cannot use as source-paths in the current version of acid.nvim.

Using my implementation of `path_to_ns` function, if users set `acid_alt_paths` correctly like following, acid.nvim works well in alternate paths.
``` vim
let g:acid_alt_paths = ["src/alts"]
```

A sample project repository is here.
https://github.com/rinx/acid-ns-experiment