### PR TITLE
Fix a bug on meta-repl window detection

### DIFF
--- a/rplugin/python3/acid/handlers/meta_repl.py
+++ b/rplugin/python3/acid/handlers/meta_repl.py
@@ -80,7 +80,7 @@ class Handler(SingletonHandler):
 
     def ensure_win_exists(self):
         no_shared_buffer = self.buf_nr is None
-        has_no_window = self.nvim.funcs.bufwinnr(self.buf_nr) == -1
+        has_no_window = no_shared_buffer or self.nvim.funcs.bufwinnr(self.buf_nr) == -1
 
         log_debug("buf_nr is {}", self.buf_nr)
         log_debug("has window? {}", has_no_window)


### PR DESCRIPTION
In my neovim 0.3.1, I got an error (shown below) when it evaluates an expression by `AcidCommand`.

I fixed it by adding just one logical operater in the line that error occured.

An error I got is:
```
error caught in async handler '/home/rinx/.config/nvim/dein/repos/github.com/clojure-vim/acid.nvim/rplugin/python3/acid:command:AcidCommand [['Eval', '(parse-int', '"3")']]'
Traceback (most recent call last):
  File "/home/rinx/.config/nvim/dein/repos/github.com/clojure-vim/acid.nvim/rplugin/python3/acid/__init__.py", line 137, in acid_command
    command.call(self, self.context(), *args)
  File "/home/rinx/.config/nvim/dein/repos/github.com/clojure-vim/acid.nvim/rplugin/python3/acid/commands/__init__.py", line 138, in call
    acid.command(payload, handlers)
  File "/home/rinx/.config/nvim/dein/repos/github.com/clojure-vim/acid.nvim/rplugin/python3/acid/__init__.py", line 112, in command
    send(self.sessions, url, handlers, data)
  File "/home/rinx/.config/nvim/dein/repos/github.com/clojure-vim/acid.nvim/rplugin/python3/acid/session.py", line 98, in send
    session.send(url, data, handlers)
  File "/home/rinx/.config/nvim/dein/repos/github.com/clojure-vim/acid.nvim/rplugin/python3/acid/session.py", line 80, in send
    handler.pre_send(data)
  File "/home/rinx/.config/nvim/dein/repos/github.com/clojure-vim/acid.nvim/rplugin/python3/acid/handlers/__init__.py", line 50, in pre_send
    self.on_pre_send(*args)
  File "/home/rinx/.config/nvim/dein/repos/github.com/clojure-vim/acid.nvim/rplugin/python3/acid/handlers/meta_repl.py", line 151, in on_pre_send
    self.ensure_win_exists()
  File "/home/rinx/.config/nvim/dein/repos/github.com/clojure-vim/acid.nvim/rplugin/python3/acid/handlers/meta_repl.py", line 83, in ensure_win_exists
    has_no_window = self.nvim.funcs.bufwinnr(self.buf_nr) == -1
  File "/home/rinx/.pyenv/versions/neovim3/lib/python3.6/site-packages/neovim/api/nvim.py", line 284, in call
    return self.request('nvim_call_function', name, args, **kwargs)
  File "/home/rinx/.pyenv/versions/neovim3/lib/python3.6/site-packages/neovim/api/nvim.py", line 170, in request
    res = self._session.request(name, *args, **kwargs)
  File "/home/rinx/.pyenv/versions/neovim3/lib/python3.6/site-packages/neovim/msgpack_rpc/session.py", line 100, in request
    raise self.error_wrapper(err)
neovim.api.nvim.NvimError: b'Vim:E5300: Expected a Number or a String'
```