### PR TITLE
Fix searching paths

### DIFF
--- a/rplugin/python3/acid/pure/__init__.py
+++ b/rplugin/python3/acid/pure/__init__.py
@@ -12,9 +12,10 @@ def path_to_ns(path, stop_paths=None):
     raw_path_list = None
 
     for stop_path in reversed(stop_paths):
-        m = re.search(stop_path, path)
+        m = re.search(stop_path[::-1], path[::-1])
         if m:
-            raw_path_list = path[m.start():].replace("_", "-").split('/')[stop_path.count('/') + 1:]
+            startpos = len(path) - m.start()
+            raw_path_list = path[startpos:].replace("_", "-").split('/')[stop_path.count('/') + 1:]
             raw_path_list[-1] = raw_path_list[-1].split('.')[0]
             break
 


### PR DESCRIPTION
I found a bug in the code that searches appropriate paths.

Using current code, it couldn't find appropriate path when a Clojure source is in a path like: `/home/rinx/local/src/github.com/sample/src/sample/core.clj`. It is because there are two same "src" directories in the path.

In this PR, it searches "src" from backward.

It's my mistake in the #22 PR. Sorry. :cry: 