### PR TITLE
Use localhost address if not provided by command

### DIFF
--- a/rplugin/python3/acid/__init__.py
+++ b/rplugin/python3/acid/__init__.py
@@ -165,10 +165,8 @@ class Acid(object):
         payload = data[0]
         handler = len(data) > 1 and data[1] or 'MetaRepl'
         config = len(data) > 2 and data[2] or None
-        url = len(data) > 3 and (
-            format_addr(*data[3]) or
-            formatted_localhost_address(self.nvim)
-        )
+        url = (format_addr(*data[3]) if len(data) > 3
+               else formatted_localhost_address(self.nvim))
 
 
         handler = self.get_handler(handler)


### PR DESCRIPTION
Some commands does not provide the nrepl url and the previous code didn't fallback to localhost properly. This PR fixes the fallback and avoid errors like these:

```
error caught in async handler '/home/daniel/.local/share/nvim/plugged/acid.nvim/rplugin/python3/acid:function:AcidSendNrepl [[{'code': "(find-ns 'async-clj-highlight)", 'op': 'eval', 'id': 'b2cf88c9059149e08792fc59ae09e9ab'}, 'VimFn', 'AsyncCljHighlightPrepare']]'         
Traceback (most recent call last):
  File "/home/daniel/.local/share/nvim/plugged/acid.nvim/rplugin/python3/acid/__init__.py", line 185, in acid_eval
    self.command(payload, [handler], url)
  File "/home/daniel/.local/share/nvim/plugged/acid.nvim/rplugin/python3/acid/__init__.py", line 112, in command
    send(self.sessions, url, handlers, data)
  File "/home/daniel/.local/share/nvim/plugged/acid.nvim/rplugin/python3/acid/session.py", line 86, in send
    session.add_atomic_watch(url, msg_id, handler, handler.matcher)
  File "/home/daniel/.local/share/nvim/plugged/acid.nvim/rplugin/python3/acid/session.py", line 51, in add_atomic_watch
    conn = self.get_or_create(url)
  File "/home/daniel/.local/share/nvim/plugged/acid.nvim/rplugin/python3/acid/session.py", line 26, in get_or_create
    conn = nrepl.connect(url)
  File "../../.local/share/nvim/plugged/acid.nvim/rplugin/python3/acid/nrepl/__init__.py", line 124, in connect
    raise ValueError("uri has no scheme: " + uri)
TypeError: can only concatenate str (not "ParseResultBytes") to str
Press ENTER or type command to continue
```