### PR TITLE
Add no-default-mapping option

### DIFF
--- a/doc/acid.txt
+++ b/doc/acid.txt
@@ -102,10 +102,19 @@ cpp		Evaluating the whole block below cursor (`AcidEval`)
 ==============================================================================
 CONFIGURATIONS					*acid-configuration*
 
+g:acid_no_default_keymappings			*acid_no_default_keymappings*
+	If it is 1, Acid doesn't set default keymappings.
+	You can specify your own keymappings like followings:
+>
+	let g:acid_no_default_keymappings = 1
 
-
-
-
+	nmap <buffer> <silent> <Leader>K      <Plug>(acid-docs)
+	nmap <buffer> <silent> <Leader><C-c>x <Plug>(acid-eval-cmdline)
+	imap <buffer> <silent> <Leader><C-c>x <Plug>(acid-eval-cmdline)
+	nmap <buffer> <silent> <Leader>cp     <Plug>(acid-motion-op)
+	nmap <buffer> <silent> <Leader>cpp    <Plug>(acid-eval-expr)
+	nmap <buffer> <silent> <Leader>cqp    <Plug>(acid-eval-print)
+<
 
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:


### PR DESCRIPTION
I added `g:acid_no_default_keymappings` option because I wanna set my own key mappings not to conflict with other plugins' key mappings.

And also I added `autocmd!` command to each autocmd group. It makes this plugin reloadable.

Thanks. :smiley: