### PR TITLE
Fix accesor function in lua/acid/middlewares/clipboard

### DIFF
--- a/lua/acid/features.lua
+++ b/lua/acid/features.lua
@@ -22,7 +22,16 @@ features.eval_cmdline = function(code, ns)
   local text = vim.api.nvim_call_function("getline", {"."})
   acid.run(ops.eval{code = code, ns = ns}:with_handler(middlewares
       .insert{
-        accessor = function(data) return data.value end,
+        accessor = function(data)
+          if data.ex ~= nil then
+            return data.ex
+          elseif data.err ~= nil then
+            return data.err
+          elseif data.out ~= nil then
+            return data.out:gsub("\n", "\\n")
+          end
+          return data.value
+        end,
         cb = cb,
         coords = curpos,
         current_line = text

--- a/lua/acid/middlewares/clipboard.lua
+++ b/lua/acid/middlewares/clipboard.lua
@@ -5,6 +5,13 @@ clipboard.name = "clipboard"
 
 clipboard.config = {
   accessor = function(data)
+    if data.ex ~= nil then
+      return data.ex
+    elseif data.err ~= nil then
+      return data.err
+    elseif data.out ~= nil then
+      return data.out:gsub("\n", "\\n")
+    end
     return data.value
   end,
   register = 'c',


### PR DESCRIPTION
When I evaluate `(println "abc")` by using `AcidMotion`, I got a exception on line 17 in clipboard.lua.
So I fixed it like this PR.

Is it correct? I don't know what is the better way to handle these values.

Thanks.