### PR TITLE
Fix/connection

### DIFF
--- a/lua/acid/core.lua
+++ b/lua/acid/core.lua
@@ -5,6 +5,7 @@
 -- @todo merge with acid and acid.connections
 local connections = require("acid.connections")
 local utils = require("acid.utils")
+local log = require("acid.log")
 
 local core = {
   indirection = {}
@@ -29,6 +30,7 @@ core.send = function(conn, obj, handler)
   if conn == nil then
     local fpath = vim.api.nvim_call_function("findfile", {".nrepl-port"})
     if fpath == "" then
+      log.msg("No active connection to a nrepl session. Aborting")
       return
     end
     local portno = table.concat(vim.api.nvim_call_function("readfile", {fpath}), "")
@@ -46,6 +48,10 @@ core.send = function(conn, obj, handler)
       conn,
       "lua"
     })
+
+  if new_conn then
+    connections:select(pwd, connections:add(new_conn))
+  end
 end
 
 return core

--- a/lua/acid/core.lua
+++ b/lua/acid/core.lua
@@ -4,6 +4,7 @@
 -- @module acid.core
 -- @todo merge with acid and acid.connections
 local connections = require("acid.connections")
+local utils = require("acid.utils")
 
 local core = {
   indirection = {}
@@ -20,8 +21,20 @@ core.send = function(conn, obj, handler)
   end
 
   local session = math.random(10000, 99999)
+  local pwd = vim.api.nvim_call_function("getcwd", {})
 
-  conn = conn or connections:get(vim.api.nvim_call_function("getcwd", {}))
+  conn = conn or connections:get(pwd)
+  local new_conn
+
+  if conn == nil then
+    local fpath = vim.api.nvim_call_function("findfile", {".nrepl-port"})
+    if fpath == "" then
+      return
+    end
+    local portno = table.concat(vim.api.nvim_call_function("readfile", {fpath}), "")
+    conn = {"127.0.0.1", utils.trim(portno)}
+    new_conn = true
+  end
 
   core.indirection[session] = {
     fn = handler,

--- a/lua/acid/log.lua
+++ b/lua/acid/log.lua
@@ -1,0 +1,8 @@
+-- luacheck: globals vim
+local log = {}
+
+log.msg = function(msg)
+  vim.api.nvim_out_write("[Acid] " .. msg .. "\n")
+end
+
+return log

--- a/lua/acid/middlewares/go_to.lua
+++ b/lua/acid/middlewares/go_to.lua
@@ -1,5 +1,6 @@
 -- luacheck: globals vim
 local nvim = vim.api
+local log = require("acid.log")
 local utils = require("acid.utils")
 local go_to = {}
 
@@ -13,8 +14,7 @@ go_to.middleware = function(config)
       local fpath = nvim.nvim_call_function("AcidFindFileInPath", {data.file, data.resource})
 
       if fpath == nil then
-        vim.api.nvim_command("echo 'File not found'")
-        vim.api.nvim_err_writeln("File not found.")
+        log.msg("File not found (" .. data.file .. ").")
         return
       end
 

--- a/lua/acid/middlewares/print.lua
+++ b/lua/acid/middlewares/print.lua
@@ -1,20 +1,21 @@
 -- luacheck: globals vim
 local do_print = {}
+local log = require("acid.log")
 
 do_print.middleware = function(config)
   return function(middleware)
     return function(data)
       if data.out ~= nil then
-        vim.api.nvim_out_write(data.out .. "\n")
+        log.msg(data.out)
       end
       if data.value ~= nil then
-        vim.api.nvim_out_write(data.value .. "\n")
+        log.msg(data.value)
       end
       if data.ex ~= nil then
-        vim.api.nvim_out_write(data.ex .. "\n")
+        log.msg(data.ex)
       end
       if data.err ~= nil then
-        vim.api.nvim_out_write(data.err .. "\n")
+        log.msg(data.err)
       end
 
       return middleware(data)

--- a/lua/acid/nrepl.lua
+++ b/lua/acid/nrepl.lua
@@ -3,6 +3,7 @@
 --- nRepl connectivity
 -- @module acid.nrepl
 local nvim = vim.api
+local log = require("acid.log")
 local utils = require("acid.utils")
 local connections = require("acid.connections")
 
@@ -173,7 +174,7 @@ nrepl.handle = {
           local opts = pending[ch]
           local port = connections.store[opts.ix][2]
           connections:select(opts.pwd, opts.ix)
-          vim.api.nvim_out_write("Acid connected on port " .. tostring(port) .. "\n")
+          log.msg("Connected on port" .. tostring(port))
           vim.api.nvim_command("doautocmd User AcidConnected")
           pending[ch] = nil
         end

--- a/lua/acid/utils.lua
+++ b/lua/acid/utils.lua
@@ -1,8 +1,12 @@
--- luacheck: globals table
+-- luacheck: globals table vim
 local utils = {}
 
 utils.pack = function (...)
   return {n=select('#',...); ...}
+end
+
+utils.trim = vim.trim or function(str)
+  return vim.api.nvim_call_function("trim", {str})
 end
 
 utils.interleave_first = function(tbl, itn)

--- a/plugin/acid.vim
+++ b/plugin/acid.vim
@@ -42,6 +42,7 @@ function! AcidSendEval(handler)
   call inputsave()
   let code = input(ns."=> ")
   call inputrestore()
+  echo
   call luaeval("require('acid.features')." . a:handler ."(_A[1], _A[2])", [code, ns])
 endfunction
 


### PR DESCRIPTION
This will make lua aware of `.nrepl-port`, so it can bail out if no connection is found instead of relying on python to check that.

Code for checking on `.nrepl-port` won't be removed from python now since it's being used by async-clj-omni to provide autocompletion if no connection is found.

A later PR will be send for that.