### PR TITLE
Fix Installation bug when using Vundle

### DIFF
--- a/doc/acid.txt
+++ b/doc/acid.txt
@@ -25,7 +25,7 @@ but evolved to be a proper clojure plugin for neovim.
 FUNCTIONS					*acid-functions*
 
 Here are documented the functions that are defined in viml. Please refer to
-*acid-remote-functions* for functions defined in python.
+|acid-remote-functions| for functions defined in python.
 
 
 :AcidFnAddRequire(require)			*AcidFnAddRequire()*


### PR DESCRIPTION
Running :helptags on the docs complains about the tag `*acid-remote-functions*` appearing twice