### PR TITLE
Admin nrepl

### DIFF
--- a/lua/acid/connections.lua
+++ b/lua/acid/connections.lua
@@ -19,9 +19,9 @@ end
 --- Stores connection for reuse later
 -- @tparam {string,string} addr Address tuple with ip and port.
 connections.add = function(addr)
-  local uuid = utils.uuid()
-  connections.store[uuid] = addr
-  return uuid
+  local ulid = utils.ulid()
+  connections.store[ulid] = addr
+  return ulid
 end
 
 connections.remove = function(addr)

--- a/lua/acid/core.lua
+++ b/lua/acid/core.lua
@@ -27,6 +27,7 @@ core.send = function(conn, obj, handler)
 
   if conn == nil then
     log.msg("No active connection to a nrepl session. Aborting")
+    return
   end
 
   if obj.id == nil then

--- a/lua/acid/init.lua
+++ b/lua/acid/init.lua
@@ -51,4 +51,29 @@ acid.callback = function(ret)
   end
 end
 
+--- Setup admin nrepl session
+-- This nrepl session should be used by plugins to deal with clojure code
+-- without injecting things in the user nrepl session
+-- or for things that clojure could deal with better while not having a 
+-- nrepl session to use.
+acid.admin_session_start = function()
+  local pwd = "/tmp/acid/admin/"
+  if require("acid.nrepl").cache[pwd] ~= nil then
+    return acid.admin_session()
+  end
+
+  local nrepl = require("acid.nrepl")
+  vim.api.nvim_call_function("mkdir", {pwd, "p"})
+  nrepl.start{pwd = pwd, skip_autocmd = true}
+end
+
+acid.admin_session = function()
+  local pwd = "/tmp/acid/admin/"
+  local conn = connections.get(pwd)
+  if conn ~= nil and conn[2] ~= nil then
+    return conn
+  end
+  return
+end
+
 return acid

--- a/lua/acid/utils.lua
+++ b/lua/acid/utils.lua
@@ -130,6 +130,7 @@ utils.random = function(sz)
 end
 
 utils.uuid = function()
+  vim.api.nvim_err_writeln("Deprecated. Please use utils.ulid instead")
  return vim.api.nvim_call_function("AcidNewUUID", {})
 end
 

--- a/plugin/acid.vim
+++ b/plugin/acid.vim
@@ -121,6 +121,7 @@ if !g:acid_no_default_keymappings
   augroup END
 endif
 
+command! -nargs=0 AcidConnectNrepl lua require('acid.nrepl').start{}
 command! -nargs=? AcidClearVtext lua require('acid.middlewares.virtualtext').clear(<f-args>)
 command! -nargs=* AcidRequire lua require('acid.features').do_require(<f-args>)
 command! -nargs=1 AcidAddRequire call AcidFnAddRequire("[<args>]")

--- a/plugin/acid.vim
+++ b/plugin/acid.vim
@@ -2,6 +2,10 @@ if !exists("g:acid_skip_test_paths")
   let g:acid_skip_test_paths = 1
 endif
 
+if !exists("g:acid_start_admin_nrepl")
+  let g:acid_start_admin_nrepl = 0
+endif
+
 let g:acid_no_default_keymappings = get(g:, 'acid_no_default_keymappings', 0)
 
 function! AcidWrappedSend(payload, handler)
@@ -119,6 +123,10 @@ if !g:acid_no_default_keymappings
     autocmd FileType clojure map <buffer> <silent> <C-c>ln <Plug>(acid-virtualtext-toggle)
     autocmd FileType clojure map <buffer> <silent> <C-c>la <Plug>(acid-virtualtext-clear-all)
   augroup END
+endif
+
+if g:acid_start_admin_nrepl
+  lua require('acid').admin_session_start()
 endif
 
 command! -nargs=0 AcidConnectNrepl lua require('acid.nrepl').start{}


### PR DESCRIPTION
This adds a nrepl session for plugins to use, before starting a nrepl itself.

This can be useful and help avoid cluttering the user nrepl with plugin code.