### PR TITLE
Support jumping to all Clojure's symbols

### DIFF
--- a/lua/acid/forms.lua
+++ b/lua/acid/forms.lua
@@ -114,9 +114,12 @@ end
 -- @treturn string symbol under cursor
 -- @treturn table coordinates {from = {row,col}, to = {row,col}, bofnr = 1}
 forms.symbol_under_cursor = function()
+  local isk = vim.api.nvim_get_option('iskeyword')
+  vim.api.nvim_command("setlocal iskeyword=" .. isk .. ",#,%,&,'")
   local cw = vim.api.nvim_call_function("expand", {"<cword>"})
   local from = vim.api.nvim_call_function("searchpos", {cw, "nc"})
   local to = vim.api.nvim_call_function("searchpos", {cw, "nce"})
+  vim.api.nvim_command("setlocal iskeyword=" .. isk)
 
   return cw, {
     from = from,


### PR DESCRIPTION
This PR supports jumping to all Clojure's symbols.

In [reference about Symbols](https://clojure.org/reference/reader#_symbols),

>Symbols begin with a non-numeric character and can contain alphanumeric characters and *, +, !, -, _, ', ?, <, > and = (other characters may be allowed eventually).

I think that other characters mean `/`, `#,` `%` and `&`. `/` has already been included in [iskeyword in Neovim v0.4.3](https://github.com/neovim/neovim/blob/v0.4.3/runtime/ftplugin/clojure.vim#L20), so I added others to iskeyword.