### PR TITLE
Babashka nrepl

### DIFF
--- a/lua/acid/connections.lua
+++ b/lua/acid/connections.lua
@@ -57,7 +57,7 @@ end
 -- @tparam[opt] string pwd path (usually project root).
 -- @treturn string Id of the current connection for the path or nil.
 connections.peek = function(pwd)
-  pwd = pwd_to_key(pwd or vim.api.nvim_call_function("getcwd", {}))
+  pwd = pwd_to_key(pwd or vim.fn.getcwd())
   return connections.current[pwd]
 end
 
@@ -76,9 +76,9 @@ end
 
 connections.search = function(pwd)
   pwd = pwd_to_key(pwd)
-  local fpath = vim.api.nvim_call_function("findfile", {pwd .. ".nrepl-port"})
+  local fpath = vim.fn.findfile(pwd .. ".nrepl-port")
   if fpath ~= "" then
-    local portno = table.concat(vim.api.nvim_call_function("readfile", {fpath}), "")
+    local portno = table.concat(vim.fn.readfile(fpath), "")
     local conn = {"127.0.0.1", utils.trim(portno)}
     return connections.add(conn)
   end

--- a/lua/acid/core.lua
+++ b/lua/acid/core.lua
@@ -43,7 +43,7 @@ core.send = function(connection, obj, handler)
   end
 
   if obj.code ~= nil then
-    output.draw(conn_id, {(obj.ns or "") .. "=> " .. obj.code})
+    output.draw(conn_id, (obj.ns or "") .. "=> " .. obj.code)
   end
 
   if obj.id == nil then

--- a/lua/acid/init.lua
+++ b/lua/acid/init.lua
@@ -8,6 +8,7 @@ local connections = require("acid.connections")
 local utils = require("acid.utils")
 local sessions = require("acid.sessions")
 local admin_session_path
+local has_bb
 local acid = {}
 
 --- Checks whether a connection exists for supplied path or not.
@@ -64,13 +65,26 @@ acid.admin_session_start = function()
     )
   end
 
+  if has_bb == nil then
+    has_bb = vim.fn.executable('bb') == 1
+  end
+
   if nrepl.cache[admin_session_path] ~= nil then
     return acid.admin_session()
   end
 
-  nrepl.bbnrepl{
-    pwd = admin_session_path,
-  }
+  if has_bb then
+    nrepl.bbnrepl{
+      pwd = admin_session_path,
+    }
+  else
+    nrepl.start{
+      pwd = admin_session_path,
+      skip_autocmd = true,
+      deps_file = admin_session_path .. "/admin_deps.edn"
+    }
+  end
+
 end
 
 acid.admin_session = function()

--- a/lua/acid/init.lua
+++ b/lua/acid/init.lua
@@ -57,24 +57,24 @@ end
 -- or for things that clojure could deal with better while not having a
 -- nrepl session to use.
 acid.admin_session_start = function()
+  local nrepl = require("acid.nrepl")
   if admin_session_path == nil then
-    admin_session_path = vim.fn.fnamemodify(vim.fn.findfile("admin_deps.edn", vim.api.nvim_get_option('rtp')), ":p:h")
+    admin_session_path = utils.ensure_path(
+      vim.fn.fnamemodify(vim.fn.findfile("admin_deps.edn", vim.api.nvim_get_option('rtp')), ":p:h")
+    )
   end
 
-  if require("acid.nrepl").cache[admin_session_path] ~= nil then
-
+  if nrepl.cache[admin_session_path] ~= nil then
     return acid.admin_session()
   end
 
-  local nrepl = require("acid.nrepl")
-  nrepl.start{
+  nrepl.bbnrepl{
     pwd = admin_session_path,
-    skip_autocmd = true,
-    deps_file = admin_session_path .. "/admin_deps.edn"
   }
 end
 
 acid.admin_session = function()
+
   local conn = connections.get(admin_session_path)
 
   if conn ~= nil and conn[2] ~= nil then

--- a/lua/acid/middlewares/output.lua
+++ b/lua/acid/middlewares/output.lua
@@ -12,26 +12,23 @@ output.middleware = function(config)
       local conn_id = sessions.reverse_lookup(session)
 
       if data.out ~= nil then
-        local out = {}
-        data.out:gsub("[^\n]+", function(dt) table.insert(out, dt) end)
-        output.draw(conn_id, out)
+        output.draw(conn_id, data.out)
       end
       if data.value ~= nil then
-        output.draw(conn_id, {"=> " .. data.value})
+        output.draw(conn_id, "=> " .. data.value)
       end
       if data.ex ~= nil then
-        output.draw(conn_id, {"!! " .. data.ex})
+        output.draw(conn_id, "!! " .. data.ex)
       end
       if data.err ~= nil then
         local out = {}
-        data.err:gsub("[^\n]+", function(dt) table.insert(out, "!! " .. dt) end)
-        output.draw(conn_id, out)
+        output.draw(conn_id, data.err)
       end
 
       if config.accessor ~= nil then
         local msg = config.accessor(data)
         if msg ~= nil and msg ~= "" then
-          output.draw(conn_id, {"<> " .. msg})
+          output.draw(conn_id, "<> " .. msg)
         end
       end
 

--- a/lua/acid/middlewares/print.lua
+++ b/lua/acid/middlewares/print.lua
@@ -26,9 +26,9 @@ do_print.middleware = function(config)
         end
       end
 
-      if utils.find(config.status, "namespace-not-found") then
+      if utils.find(data.status, "namespace-not-found") then
         log.msg("Namespace not found")
-      elseif utils.find(config.status, "error") then
+      elseif utils.find(data.status, "error") then
         log.msg("Error")
       end
 

--- a/lua/acid/middlewares/quickfix.lua
+++ b/lua/acid/middlewares/quickfix.lua
@@ -30,7 +30,6 @@ quickfix.set = function(config)
                   '**/' .. assert.file,
                   false,
                   true)[1]
-                tap(fpath)
                 table.insert(qf, {
                   module = ns .. "/" .. test,
                   lnum  = assert.line,
@@ -42,7 +41,6 @@ quickfix.set = function(config)
             end
           end
         end
-        tap(qf)
         vim.fn.setqflist({}, 'r', {
             id = config.qflistid,
             items = qf

--- a/lua/acid/nrepl.lua
+++ b/lua/acid/nrepl.lua
@@ -79,15 +79,6 @@ local build_cmd = function(obj)
     table.insert(opts, obj.bind)
   end
 
-  if obj.host ~= nil or obj.connect ~= nil then
-    table.insert(opts,"-c")
-  end
-
-  if obj.host ~= nil then
-    table.insert(opts,"-h")
-    table.insert(opts, obj.host)
-  end
-
   return opts
 end
 
@@ -102,17 +93,13 @@ nrepl.default_middlewares = {'nrepl/nrepl', 'cider/cider-nrepl', 'refactor-nrepl
 -- @tparam[opt] string obj.pwd Path where the nrepl process will be started
 -- @tparam[opt] table obj.middlewares List of middlewares.
 -- @tparam[opt] string obj.alias aliases on the local deps.edn
--- @tparam[opt] string obj.connect -c parameter for the nrepl process
+-- @tparam[opt] int obj.port -p parameter for the nrepl process
 -- @tparam[opt] string obj.bind -b parameter for the nrepl process
 -- @tparam[opt] boolean obj.skip_autocmd don't fire an autocmd after starting this repl
 -- @tparam[opt] boolean obj.disable_output_capture disables output capturing.
 -- @treturn boolean Whether it was possible to spawn a nrepl process
 nrepl.start = function(obj)
-  local pwd = obj.pwd or vim.api.nvim_call_function("getcwd", {})
-
-  if not utils.ends_with(pwd, "/") then
-    pwd = pwd .. "/"
-  end
+  local pwd = utils.ensure_path(obj.pwd or vim.api.nvim_call_function("getcwd", {}))
 
   local selected = obj.middlewares or nrepl.default_middlewares
   local bind = obj.bind
@@ -121,8 +108,6 @@ nrepl.start = function(obj)
     port = obj.port,
     alias = obj.alias,
     bind = obj.bind,
-    host = obj.host,
-    connect = obj.connect,
     deps_file = obj.deps_file
   }
 
@@ -139,7 +124,7 @@ nrepl.start = function(obj)
 
    if ret <= 0 then
      -- TODO log, inform..
-     return
+     return false
    end
 
    local conn = {bind, obj.port}

--- a/lua/acid/sessions.lua
+++ b/lua/acid/sessions.lua
@@ -1,6 +1,7 @@
 -- luacheck: globals vim
 local connections = require("acid.connections")
 local ops = require("acid.ops")
+local utils = require("acid.utils")
 local core = require("acid.core")
 
 local pwd_to_key = function(pwd)

--- a/lua/acid/utils.lua
+++ b/lua/acid/utils.lua
@@ -5,6 +5,13 @@ utils.pack = function (...)
   return {n=select('#',...); ...}
 end
 
+utils.ensure_path = function(pwd)
+  if not utils.ends_with(pwd, "/") then
+    pwd = pwd .. "/"
+  end
+  return pwd
+end
+
 
 
 utils.trim = vim.trim or function(str)


### PR DESCRIPTION
This PR adds a lot of stuff that was minor, but two major things:

* Output buffer for printing nrepl eval communication
* Replaces admin session for a [babashka](https://github.com/borkdude/babashka) nrepl server if it exists in path

Since the admin session is supposed to be used only for very lightweight operations, babashka is perfect for the task.

Additionally, it allows for frontends (such as [jazz.nvim](https://github.com/clojure-vim/jazz.nvim)) to spawn babashka nrepl sessions.